### PR TITLE
Deleting unused CredentialsAwsGlobalConfiguration.ENDPOINT field

### DIFF
--- a/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
@@ -68,11 +68,6 @@ import jenkins.model.Jenkins;
 public class CredentialsAwsGlobalConfiguration extends AbstractAwsGlobalConfiguration {
 
     /**
-     * field to fake endpoint on test.
-     */
-    static AwsClientBuilder.EndpointConfiguration ENDPOINT;
-
-    /**
      * Session token duration in seconds.
      */
     @SuppressWarnings("FieldMayBeFinal")
@@ -196,9 +191,7 @@ public class CredentialsAwsGlobalConfiguration extends AbstractAwsGlobalConfigur
      */
     public AWSSessionCredentials sessionCredentials(AwsClientBuilder<?, ?> builder) throws IOException {
         AWSSessionCredentials awsCredentials;
-        if (ENDPOINT != null) {
-            awsCredentials = new BasicSessionCredentials("FakeKey", "FakeSecret", "FakeToken");
-        } else if (hasCredentialsConfigured()) {
+        if (hasCredentialsConfigured()) {
             awsCredentials = sessionCredentialsFromKeyAndSecret();
         } else {
             awsCredentials = sessionCredentialsFromInstanceProfile(builder);


### PR DESCRIPTION
Apparently copy-pasted from `S3BlobStoreConfig` which actually uses it in tests.