### PR TITLE
[JENKINS-56004] Do not check ADMINISTER on internal methods

### DIFF
--- a/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
@@ -126,7 +126,6 @@ public class CredentialsAwsGlobalConfiguration extends AbstractAwsGlobalConfigur
     }
 
     public AmazonWebServicesCredentials getCredentials(String credentialsId) {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         Optional<AmazonWebServicesCredentials> credential = CredentialsProvider
                 .lookupCredentials(AmazonWebServicesCredentials.class, Jenkins.get(), ACL.SYSTEM,
                         Collections.emptyList())


### PR DESCRIPTION
[JENKINS-56004](https://issues.jenkins-ci.org/browse/JENKINS-56004)

We already check `ADMINISTER` in configuration-time web methods in `CredentialsAwsGlobalConfiguration`, `S3BlobStoreConfig`, and `CloudWatchAwsGlobalConfiguration`. Checking it in `getCredentials(String)` prevents non-admins from browsing artifacts when there are explicit (i.e., not instance profile) credentials configured—the call is being made _by_ system code _on behalf of_ some user call. (If there were a need for more subtlety we could also use an `ACL.as(SYSTEM)` block.)