### PR TITLE
Java 11 readiness: build on recommended configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.21</version>
+        <version>3.40</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -16,7 +16,6 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
-        <powermock.version>1.7.1</powermock.version>
     </properties>
     <name>AWS Global Configuration Plugin</name>
     <description>Configure all AWS related plugins from a single page</description>
@@ -64,19 +63,17 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.9</version>
+            <version>2.25.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.25.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfigurationMockTest.java
+++ b/src/test/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfigurationMockTest.java
@@ -60,7 +60,7 @@ import org.junit.Ignore;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ CredentialsAwsGlobalConfiguration.class, Jenkins.class, AWSSecurityTokenServiceClientBuilder.class })
 @PowerMockIgnore({ "javax.management.*", "org.apache.http.conn.ssl.*", "com.amazonaws.http.conn.ssl.*",
-        "javax.net.ssl.*" })
+        "javax.net.ssl.*", "javax.xml.*" })
 public class CredentialsAwsGlobalConfigurationMockTest {
 
     private static String CREDENTIALS_ID = "CredentialsAwsGlobalConfigurationMockTest";


### PR DESCRIPTION
For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.
