### PR TITLE
Dropping Java 8 from CI, introducing Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 buildPlugin(configurations: [
-    [platform: 'linux', jdk: '8'],
+    useContainerAgent: true,
     [platform: 'linux', jdk: '11'],
     [platform: 'windows', jdk: '11'],
+    [platform: 'linux', jdk: 17]
 ])


### PR DESCRIPTION
Hello folks :wave:

I'm currently following the [Improve a Plugin documentation](https://www.jenkins.io/doc/developer/tutorial-improve/) for
Jenkins plugins modernization, and noticed we could [update the Jenkinsfile](https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/) for this plugin.

On top of dropping Java 8 builds for this plugin, this also introduces Java 17 builds. Let me know if that makes sense for you or if you'd like to go for Java 17 only as it is advised in the improve documentation.

So here's a PR doing that. I checked that everything is running fine with `mvn verify`.

Thanks for your review!

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
