### PR TITLE
[JENKINS-75014] Allow `auth` module to see `sts` module classes

### DIFF
--- a/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import jenkins.model.Jenkins;
+import jenkins.util.SetContextClassLoader;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -182,7 +183,8 @@ public final class CredentialsAwsGlobalConfiguration extends AbstractAwsGlobalCo
      *             in case of error.
      */
     private AwsSessionCredentials sessionCredentialsFromInstanceProfile() throws IOException {
-        try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
+        try (SetContextClassLoader sccl = new SetContextClassLoader(CredentialsAwsGlobalConfiguration.class);
+                DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
             AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
 
             // Assume we are using session credentials


### PR DESCRIPTION
Before this PR, I was seeing https://github.com/aws/aws-sdk-java-v2/blob/84b5a6cb7530eb332dec50581d8f490a23ca4531/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/WebIdentityCredentialsUtils.java#L49 which took me to https://github.com/aws/aws-sdk-java-v2/blob/84b5a6cb7530eb332dec50581d8f490a23ca4531/utils/src/main/java/software/amazon/awssdk/utils/ClassLoaderHelper.java#L124, showing that this code needs `SetContextClassLoader` to work with the Jenkins plugin class loading system.

### Testing done

After this PR, could no longer reproduce the exception described in the issue description.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
