### PR TITLE
[JENKINS-75020] "`IllegalStateException`: Connection pool shut down" when using IRSA and aws-sdk-v2

### DIFF
--- a/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aws/global_configuration/CredentialsAwsGlobalConfiguration.java
@@ -182,15 +182,14 @@ public final class CredentialsAwsGlobalConfiguration extends AbstractAwsGlobalCo
      *             in case of error.
      */
     private AwsSessionCredentials sessionCredentialsFromInstanceProfile() throws IOException {
-        try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
-            AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
+        DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+        AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
 
-            // Assume we are using session credentials
-            if (!(awsCredentials instanceof AwsSessionCredentials)) {
-                throw new IOException("No valid session credentials");
-            }
-            return (AwsSessionCredentials) awsCredentials;
+        // Assume we are using session credentials
+        if (!(awsCredentials instanceof AwsSessionCredentials)) {
+            throw new IOException("No valid session credentials");
         }
+        return (AwsSessionCredentials) awsCredentials;
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-75020](https://issues.jenkins.io/browse/JENKINS-75020). https://github.com/aws/aws-sdk-java-v2/issues/4386 explains that the default credentials provider cannot be closed, as it prevents subsequent refresh operations from succeeding.